### PR TITLE
Component is an interface. Input allows holding a key, repeating until released.

### DIFF
--- a/core/src/main/java/roguelike/Components/AI.java
+++ b/core/src/main/java/roguelike/Components/AI.java
@@ -1,10 +1,8 @@
 package roguelike.Components;
 
-import roguelike.Actions.Move;
 import roguelike.Enums.AI_MODE;
-import roguelike.utilities.Point;
 
-public class AI extends Component{
+public class AI implements Component{
 
 	public AI_MODE mode;
 

--- a/core/src/main/java/roguelike/Components/Action_Component.java
+++ b/core/src/main/java/roguelike/Components/Action_Component.java
@@ -4,7 +4,7 @@ import lombok.Setter;
 import roguelike.Actions.Action;
 
 @Setter
-public class Action_Component extends Component{
+public class Action_Component implements Component{
 	private Action action;
 
 	public Action_Component(){ }

--- a/core/src/main/java/roguelike/Components/Active.java
+++ b/core/src/main/java/roguelike/Components/Active.java
@@ -1,4 +1,4 @@
 package roguelike.Components;
 
-public class Active extends Component{
+public class Active implements Component{
 }

--- a/core/src/main/java/roguelike/Components/Armor.java
+++ b/core/src/main/java/roguelike/Components/Armor.java
@@ -2,7 +2,7 @@ package roguelike.Components;
 
 import org.json.simple.JSONObject;
 
-public class Armor extends Component{
+public class Armor implements Component{
 
 	public int piercing;
 	public int slashing;

--- a/core/src/main/java/roguelike/Components/Command.java
+++ b/core/src/main/java/roguelike/Components/Command.java
@@ -1,93 +1,72 @@
 package roguelike.Components;
 
-import com.badlogic.gdx.Input;
-import com.badlogic.gdx.InputProcessor;
 import lombok.Getter;
 import roguelike.Actions.Action;
 import roguelike.Actions.Exit_Through;
 import roguelike.Actions.Move;
 import roguelike.engine.Message_Log;
 import roguelike.utilities.Point;
+import squidpony.squidgrid.gui.gdx.SquidInput;
 
 import static roguelike.Generation.World.entityManager;
 
 @Getter
-public class Command extends Component implements InputProcessor{
+public class Command extends SquidInput implements Component {
 
 	private Integer entity;
 	private Action action;
-	public Command(final Integer entity){
+	public Command(final Integer entity) {
+		super();
 		this.entity = entity;
+		setKeyHandler(new KH());
 	}
+	private class KH implements KeyHandler
+	{
+			/**
+			 * The only method you need to implement yourself in KeyHandler, this should react to keys such as
+			 * 'a' (produced by pressing the A key while not holding Shift), 'E' (produced by pressing the E key while
+			 * holding Shift), and '\u2190' (left arrow in unicode, also available as a constant in SquidInput, produced by
+			 * pressing the left arrow key even though that key does not have a default unicode representation). Capital
+			 * letters will be capitalized when they are passed to this, but they may or may not have the shift argument as
+			 * true depending on how this method was called. Symbols that may be produced by holding Shift and pressing a
+			 * number or a symbol key can vary between keyboards (some may require Shift to be held down, others may not).
+			 * <br>
+			 * This can react to the input in whatever way you find appropriate for your game.
+			 *
+			 * @param key   a char of the "typed" representation of the key, such as 'a' or 'E', or if there is no Unicode
+			 *              character for the key, an appropriate alternate character as documented in SquidInput.fromKey()
+			 * @param alt   true if the Alt modifier was being held while this key was entered, false otherwise.
+			 * @param ctrl  true if the Ctrl modifier was being held while this key was entered, false otherwise.
+			 * @param shift true if the Shift modifier was being held while this key was entered, false otherwise.
+			 */
+			@Override
+			public void handle(char key, boolean alt, boolean ctrl, boolean shift) {
+			switch(key){
+				case DOWN_LEFT_ARROW:
+					action = new Move(entity, Point.SOUTH_WEST); break;
+				case DOWN_ARROW:
+					action = new Move(entity, Point.SOUTH); break;
+				case DOWN_RIGHT_ARROW:
+					action = new Move(entity, Point.SOUTH_EAST); break;
+				case LEFT_ARROW:
+					action = new Move(entity, Point.WEST); break;
+				case CENTER_ARROW:
+					action = new Move(entity, Point.WAIT); break;
+				case RIGHT_ARROW:
+					action = new Move(entity, Point.EAST); break;
+				case UP_LEFT_ARROW:
+					action = new Move(entity, Point.NORTH_WEST); break;
+				case UP_ARROW:
+					action = new Move(entity, Point.NORTH); break;
+				case UP_RIGHT_ARROW:
+					action = new Move(entity, Point.NORTH_EAST); break;
+				case ENTER:
+					action = new Exit_Through(entity); break;
+			}
 
-	@Override
-	public boolean keyDown(int keycode) {
-
-		switch(keycode){
-			case Input.Keys.NUMPAD_1:
-				action = new Move(entity, Point.SOUTH_WEST); break;
-			case Input.Keys.DOWN:
-			case Input.Keys.NUMPAD_2:
-				action = new Move(entity, Point.SOUTH); break;
-			case Input.Keys.NUMPAD_3:
-				action = new Move(entity, Point.SOUTH_EAST); break;
-			case Input.Keys.LEFT:
-			case Input.Keys.NUMPAD_4:
-				action = new Move(entity, Point.WEST); break;
-			case Input.Keys.NUMPAD_5:
-				action = new Move(entity, Point.WAIT); break;
-			case Input.Keys.RIGHT:
-			case Input.Keys.NUMPAD_6:
-				action = new Move(entity, Point.EAST); break;
-			case Input.Keys.NUMPAD_7:
-				action = new Move(entity, Point.NORTH_WEST); break;
-			case Input.Keys.UP:
-			case Input.Keys.NUMPAD_8:
-				action = new Move(entity, Point.NORTH); break;
-			case Input.Keys.NUMPAD_9:
-				action = new Move(entity, Point.NORTH_EAST); break;
-			case Input.Keys.ENTER:
-				action = new Exit_Through(entity); break;
+			Message_Log.getInstance().ticks++;
+			Message_Log.getInstance().check_ticks();
+			entityManager.gc(entity, Action_Component.class).setAction(action);
 		}
-
-		Message_Log.getInstance().ticks++;
-		Message_Log.getInstance().check_ticks();
-		entityManager.gc(entity, Action_Component.class).setAction(action);
-		return true;
-	}
-
-	@Override
-	public boolean keyUp(int keycode) {
-		return false;
-	}
-
-	@Override
-	public boolean keyTyped(char character) {
-		return false;
-	}
-
-	@Override
-	public boolean touchDown(int screenX, int screenY, int pointer, int button) {
-		return false;
-	}
-
-	@Override
-	public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-		return false;
-	}
-
-	@Override
-	public boolean touchDragged(int screenX, int screenY, int pointer) {
-		return false;
-	}
-
-	@Override
-	public boolean mouseMoved(int screenX, int screenY) {
-		return false;
-	}
-
-	@Override
-	public boolean scrolled(int amount) {
-		return false;
 	}
 }

--- a/core/src/main/java/roguelike/Components/Component.java
+++ b/core/src/main/java/roguelike/Components/Component.java
@@ -1,4 +1,4 @@
 package roguelike.Components;
 
-public class Component {
+public interface Component {
 }

--- a/core/src/main/java/roguelike/Components/Details.java
+++ b/core/src/main/java/roguelike/Components/Details.java
@@ -2,7 +2,7 @@ package roguelike.Components;
 
 import org.json.simple.JSONObject;
 
-public class Details extends Component{
+public class Details implements Component{
 	public String name;
 	public String description;
 

--- a/core/src/main/java/roguelike/Components/Energy.java
+++ b/core/src/main/java/roguelike/Components/Energy.java
@@ -1,6 +1,6 @@
 package roguelike.Components;
 
-public class Energy extends Component{
+public class Energy implements Component{
 
 	public int speed;
 	public int energy;

--- a/core/src/main/java/roguelike/Components/Equipment.java
+++ b/core/src/main/java/roguelike/Components/Equipment.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 
 import static roguelike.Generation.World.entityManager;
 
-public class Equipment extends Component{
+public class Equipment implements Component{
 	public HashMap<Equipment_Slot, Integer> equipment;
 
 	public Equipment(){

--- a/core/src/main/java/roguelike/Components/Equippable.java
+++ b/core/src/main/java/roguelike/Components/Equippable.java
@@ -6,7 +6,7 @@ import roguelike.Enums.Equipment_Slot;
 import java.util.ArrayList;
 import java.util.Set;
 
-public class Equippable extends Component{
+public class Equippable implements Component{
 	public ArrayList<Equipment_Slot> slots;
 
 	public Equippable(JSONObject object){

--- a/core/src/main/java/roguelike/Components/Inventory.java
+++ b/core/src/main/java/roguelike/Components/Inventory.java
@@ -2,7 +2,7 @@ package roguelike.Components;
 
 import java.util.ArrayList;
 
-public class Inventory extends Component{
+public class Inventory implements Component{
 
 	public ArrayList<Integer> inventory;
 

--- a/core/src/main/java/roguelike/Components/Offensive_Component.java
+++ b/core/src/main/java/roguelike/Components/Offensive_Component.java
@@ -5,7 +5,7 @@ import roguelike.Effects.Damage;
 
 import java.util.ArrayList;
 
-public class Offensive_Component extends Component{
+public class Offensive_Component implements Component{
 
 	public ArrayList<Damage> damages;
 

--- a/core/src/main/java/roguelike/Components/Position.java
+++ b/core/src/main/java/roguelike/Components/Position.java
@@ -3,7 +3,7 @@ package roguelike.Components;
 import roguelike.Generation.Map;
 import squidpony.squidmath.Coord;
 
-public class Position extends Component{
+public class Position implements Component{
 
 	public Coord location;
 	public Map map;

--- a/core/src/main/java/roguelike/Components/Sprite.java
+++ b/core/src/main/java/roguelike/Components/Sprite.java
@@ -4,7 +4,7 @@ import com.badlogic.gdx.graphics.Color;
 import org.json.simple.JSONObject;
 import roguelike.utilities.Colors;
 
-public class Sprite extends Component {
+public class Sprite implements Component {
     public char character;
     public Color backgroundColor;
     public Color foregroundColor;

--- a/core/src/main/java/roguelike/Components/Statistics.java
+++ b/core/src/main/java/roguelike/Components/Statistics.java
@@ -3,7 +3,7 @@ package roguelike.Components;
 import org.json.simple.JSONObject;
 import roguelike.utilities.Limited_Statistic;
 
-public class Statistics extends Component{
+public class Statistics implements Component{
 
 	public Limited_Statistic health;
 

--- a/core/src/main/java/roguelike/Components/Vision.java
+++ b/core/src/main/java/roguelike/Components/Vision.java
@@ -8,7 +8,7 @@ import squidpony.squidgrid.mapping.DungeonUtility;
 import squidpony.squidmath.Coord;
 
 @Getter
-public class Vision extends Component{
+public class Vision implements Component{
 
 	private Coord location;
 	private Map map;

--- a/core/src/main/java/roguelike/Generation/World.java
+++ b/core/src/main/java/roguelike/Generation/World.java
@@ -6,13 +6,10 @@ import lombok.Setter;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import roguelike.Components.Action_Component;
 import roguelike.Components.Command;
 import roguelike.Components.Position;
-import roguelike.Systems.AI_System;
 import roguelike.Systems.Turn_System;
 import roguelike.engine.EntityManager;
-import roguelike.utilities.Roll;
 import squidpony.squidmath.Coord;
 
 import java.io.IOException;
@@ -60,6 +57,7 @@ public class World {
 
 		player = Factory.getInstance().initialize_player();
 		Factory.getInstance().build_player(player, starting_location, surface);
+		//Gdx.input.setInputProcessor(entityManager.gc(player, Command.class));
 		Gdx.input.setInputProcessor(entityManager.gc(player, Command.class));
 
 		turn_system = new Turn_System();

--- a/core/src/main/java/roguelike/Systems/Turn_System.java
+++ b/core/src/main/java/roguelike/Systems/Turn_System.java
@@ -3,11 +3,10 @@ package roguelike.Systems;
 import roguelike.Actions.Action;
 import roguelike.Components.Action_Component;
 import roguelike.Components.Active;
+import roguelike.Components.Command;
 import roguelike.Components.Energy;
-import roguelike.engine.Message_Log;
 
 import java.util.ArrayList;
-import java.util.Collections;
 
 import static roguelike.Generation.World.entityManager;
 
@@ -23,7 +22,7 @@ public class Turn_System implements Base_System {
 	@Override
 	public void process() {
 		ArrayList<Integer> actors = new ArrayList<>(entityManager.getAllEntitiesPossessingComponent(Active.class));
-		Collections.sort(actors, (a, b) -> a < b ? -1 : a.equals(b) ? 0 : 1);
+		actors.sort((a, b) -> a < b ? -1 : a.equals(b) ? 0 : 1);
 		int current_actor = actors.get(0);
 
 		this.AI_System = new AI_System(actors);
@@ -31,7 +30,11 @@ public class Turn_System implements Base_System {
 		while(true){
 
 			AI_System.process();
-
+			Command command = entityManager.gc(current_actor, Command.class);
+			if(command != null && command.hasNext())
+			{
+				command.next();
+			}
 			Action action = entityManager.gc(current_actor, Action_Component.class).getAction();
 
 			if(action != null) {

--- a/core/src/main/java/roguelike/engine/EntityManager.java
+++ b/core/src/main/java/roguelike/engine/EntityManager.java
@@ -8,7 +8,7 @@ public class EntityManager
 {
 	private int lowestUnassignedEntityID=0;
 	private List<Integer> allEntities;
-	private HashMap<Class<?>, HashMap<Integer, ? extends Component>> componentStores;
+	private HashMap<Class<?>, HashMap<Integer, Component>> componentStores;
 
 	public EntityManager()
 	{
@@ -18,7 +18,7 @@ public class EntityManager
 
 	public <T extends Component> T gc(int entity, Class<T> componentType)
 	{
-		HashMap<Integer, ? extends Component> store = componentStores.get( componentType );
+		HashMap<Integer, Component> store = componentStores.get( componentType );
 
 		if( store == null)
 			return null;
@@ -36,7 +36,7 @@ public class EntityManager
 
 	public <T extends Component> List<T> getAllComponentsOfType( Class<T> componentType )
 	{
-		HashMap<Integer, ? extends Component> store = componentStores.get( componentType );
+		HashMap<Integer, Component> store = componentStores.get( componentType );
 
 		if( store == null )
 		{
@@ -50,7 +50,7 @@ public class EntityManager
 
 	public <T extends Component> Set<Integer> getAllEntitiesPossessingComponent(Class<T> componentType )
 	{
-		HashMap<Integer, ? extends Component> store = componentStores.get( componentType );
+		HashMap<Integer, Component> store = componentStores.get( componentType );
 
 		if( store == null)
 			return new HashSet<>();
@@ -60,7 +60,7 @@ public class EntityManager
 
 	public <T extends Component> void addComponent( int entity, T component )
 	{
-		HashMap<Integer, ? extends Component> store = componentStores.get( component.getClass() );
+		HashMap<Integer, Component> store = componentStores.get( component.getClass() );
 
 		if( store == null )
 		{
@@ -93,7 +93,7 @@ public class EntityManager
 		synchronized( this ) // prevent it generating two entities with same ID at once
 		{
 			allEntities.remove(entity);
-			for( HashMap<Integer, ? extends Component> store : componentStores.values() )
+			for( HashMap<Integer, Component> store : componentStores.values() )
 			{
 				store.remove(entity);
 			}

--- a/core/src/main/java/roguelike/utilities/Limited_Statistic.java
+++ b/core/src/main/java/roguelike/utilities/Limited_Statistic.java
@@ -25,9 +25,9 @@ public class Limited_Statistic {
 
 	public void setValue(int value){
 		if(value < minimum)
-			setValue(minimum);
+			this.current_value = minimum;
 		else if(value > maximum)
-			setValue(maximum);
+			this.current_value = maximum;
 		else
 			this.current_value = value;
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx512m
 org.gradle.configureondemand=false
-regExodusVersion=0.1.9
-squidLibVersion=031579b1fa
+regExodusVersion=0.1.10
+squidLibVersion=1d9ce00fe1
 gdxVersion=1.9.8


### PR DESCRIPTION
The interface changes were mostly automatic, but `<? extends Component>` can now just be `<Component>`, anything else that extended Component now implements it instead, and that's about it.

Command now implements Component and extends SquidInput, which gives it the ability to be stored in EntityManager while having the state of a SquidInput, like the queue of events.

Turn_System needed a minor change so it can advance the SquidInput if there is input that still needs to be processed. Specifically, the hasNext() method on SquidInput and/or Command needs to be called often, probably every frame, for key repeat delays to be calculated accurately. If hasNext() is true, it handles it in Turn_System by calling Command's next() method, which is used by the subsequent step with the Action_Component assigned by the Command. Command needed to be a Component so it could be easily obtained in Turn_System.