### PR TITLE
Fix issue with input and screens

### DIFF
--- a/core/src/main/java/roguelike/Generation/Factory.java
+++ b/core/src/main/java/roguelike/Generation/Factory.java
@@ -3,14 +3,10 @@ package roguelike.Generation;
 import com.badlogic.gdx.Gdx;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import roguelike.Components.*;
 import roguelike.Enums.Equipment_Slot;
 import roguelike.engine.Game;
-import roguelike.utilities.Point;
 import squidpony.squidmath.Coord;
-
-import java.io.IOException;
 
 import static roguelike.Generation.World.entityManager;
 
@@ -23,13 +19,19 @@ public class Factory {
 	private JSONObject races;
 	private JSONObject items;
 
-	private Factory() throws IOException, ParseException {
+	private Factory() {
 		JSONParser parser = new JSONParser();
-		races = (JSONObject)parser.parse(Gdx.files.internal("races.txt").reader());
-		items = (JSONObject)parser.parse(Gdx.files.internal("items.txt").reader());
+		try {
+			races = (JSONObject) parser.parse(Gdx.files.internal("races.txt").reader());
+			items = (JSONObject) parser.parse(Gdx.files.internal("items.txt").reader());
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
 	}
 
-	public static Factory getInstance() throws IOException, ParseException {
+	public static Factory getInstance() {
 		if(factory == null)
 			factory = new Factory();
 

--- a/core/src/main/java/roguelike/Generation/World.java
+++ b/core/src/main/java/roguelike/Generation/World.java
@@ -5,14 +5,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import roguelike.Components.Command;
 import roguelike.Components.Position;
 import roguelike.Systems.Turn_System;
 import roguelike.engine.EntityManager;
 import squidpony.squidmath.Coord;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Scanner;
 
@@ -39,14 +37,19 @@ public class World {
 
 	public ArrayList<Exit> surface_exits;
 
-	public World(int map_width, int map_height) throws IOException, ParseException {
+	public World(int map_width, int map_height) {
 		this.map_width = map_width;
 		this.map_height = map_height;
 
 		surface_exits = new ArrayList<>();
 
 		JSONParser parser = new JSONParser();
-		tiles = (JSONObject)parser.parse(Gdx.files.internal("tiles.txt").reader());
+		try {
+			tiles = (JSONObject)parser.parse(Gdx.files.internal("tiles.txt").reader());
+		} catch (Exception e)
+		{
+			e.printStackTrace();
+		}
 		first_dungeon = new Dungeon("Main Dungeon", 25);
 		surface = new Map(initializeMapWithFile("surface.txt"));
 		first_dungeon.add_level(0, surface);

--- a/core/src/main/java/roguelike/engine/Game.java
+++ b/core/src/main/java/roguelike/engine/Game.java
@@ -1,20 +1,13 @@
 package roguelike.engine;
 
-import com.badlogic.gdx.ApplicationAdapter;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
-import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.StretchViewport;
 import lombok.Getter;
 import lombok.Setter;
-import org.json.simple.parser.ParseException;
 import roguelike.screens.Game_Screen;
-import roguelike.screens.Screen;
 import roguelike.screens.Start_Screen;
-
-import java.io.IOException;
 
 @Getter @Setter
 public class Game extends com.badlogic.gdx.Game {
@@ -42,11 +35,7 @@ public class Game extends com.badlogic.gdx.Game {
 
         stage = new Stage(mainViewport, batch);
 
-	    try {
-		    game_screen = new Game_Screen(this);
-	    } catch (IOException | ParseException e) {
-		    e.printStackTrace();
-	    }
+        game_screen = new Game_Screen(this);
 
 
 	    setScreen(new Start_Screen(this));

--- a/core/src/main/java/roguelike/screens/Game_Screen.java
+++ b/core/src/main/java/roguelike/screens/Game_Screen.java
@@ -3,7 +3,6 @@ package roguelike.screens;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import org.json.simple.parser.ParseException;
 import roguelike.Components.*;
 import roguelike.Effects.Damage;
 import roguelike.Generation.Factory;
@@ -16,7 +15,6 @@ import squidpony.squidgrid.gui.gdx.SColor;
 import squidpony.squidgrid.gui.gdx.SparseLayers;
 import squidpony.squidmath.Coord;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Set;
 
@@ -36,9 +34,13 @@ public class Game_Screen extends ScreenAdapter {
     private int map_height_start;
     private int map_height_end;
 
-    public Game_Screen(Game game_in) throws IOException, ParseException{
+    public Game_Screen(Game game_in){
         game = game_in;
         Factory.getInstance().setGame(game_in);
+    }
+
+    @Override
+    public void show(){
         stage = game.stage;
         display = new SparseLayers(gridWidth, gridHeight, cellWidth, cellHeight, DefaultResources.getCrispDejaVuFont());
         display.font.tweakWidth(cellWidth + 1).tweakHeight(cellHeight + 1).setSmoothingMultiplier(1.6f).initBySize();
@@ -48,8 +50,9 @@ public class Game_Screen extends ScreenAdapter {
         display.fillBackground(bgColor);
         map_height_start = message_buffer;
         map_height_end = gridHeight - statistics_height + message_buffer;
-		world = new World(gridWidth, gridHeight - statistics_height);
+        world = new World(gridWidth, gridHeight - statistics_height);
         stage.addActor(display);
+
     }
 
     @Override

--- a/core/src/main/java/roguelike/screens/Start_Screen.java
+++ b/core/src/main/java/roguelike/screens/Start_Screen.java
@@ -1,18 +1,14 @@
 package roguelike.screens;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import org.json.simple.parser.ParseException;
 import roguelike.engine.Game;
 import squidpony.squidgrid.gui.gdx.DefaultResources;
 import squidpony.squidgrid.gui.gdx.SColor;
 import squidpony.squidgrid.gui.gdx.SparseLayers;
 import squidpony.squidgrid.gui.gdx.SquidInput;
-
-import java.io.IOException;
 
 import static roguelike.engine.Game.*;
 
@@ -34,23 +30,21 @@ public class Start_Screen extends ScreenAdapter {
         bgColor = SColor.DB_MIDNIGHT;
         display.fillBackground(bgColor);
         stage.addActor(display);
-
     }
 
     @Override
     public void show(){
 	    input = new SquidInput((key, alt, ctrl, shift) -> {
 
-		    switch(key){
-			    case SquidInput.ENTER:
-			    {
-			    	game.setScreen(game.getGame_screen());
-				    break;
-			    }
-		    }
+		    switch(key) {
+                case SquidInput.ENTER: {
+                    game.setScreen(game.getGame_screen());
+                    break;
+                }
+            }
 	    });
 
-	    Gdx.input.setInputProcessor(new InputMultiplexer(stage, input));
+	    Gdx.input.setInputProcessor(input);
     }
 
     @Override
@@ -68,6 +62,13 @@ public class Start_Screen extends ScreenAdapter {
 
 	@Override
 	public void hide(){
-		Gdx.input.setInputProcessor(null);
+//        if(input != null)
+//            input.setIgnoreInput(true);
 	}
+
+    @Override
+    public void resume() {
+//        if(input != null)
+//            input.setIgnoreInput(true);
+    }
 }


### PR DESCRIPTION
The cause of the issue is kinda weird and complicated, but I think it was that the player input was being assigned in World's constructor, and that was called in Game_Screen's constructor instead of Game_Screen.show(). The screen constructor is called while the start screen is still active, so when the start screen was hidden it would call Start_Screen.hide() and stop listening to input. By moving logic to show(), it happens after the Game_Screen just started showing and should now respond to input.

Most of the changes here are to Screens, but the checked exceptions in some constructor and method types also needed to go since show() in Screen doesn't have in its type that it throws any Exceptions (it should probably use try/catch internally).