### PR TITLE
Equip screen can be dismissed with enter

### DIFF
--- a/core/src/main/java/roguelike/Components/Command.java
+++ b/core/src/main/java/roguelike/Components/Command.java
@@ -30,6 +30,7 @@ public class Command extends SquidInput implements Component {
 
 		this.equipment_screen = new Equipment_Screen(entity, game);
 	}
+
 	private class KH implements KeyHandler
 	{
 			/**
@@ -73,6 +74,7 @@ public class Command extends SquidInput implements Component {
 				case ENTER:
 					action = new Exit_Through(entity); break;
 				case 'e':
+					lastKeyCode = -1; // needed because this class won't be used to handle input after the screen switch
 					game.setScreen(equipment_screen); break;
 				default:
 					return;

--- a/core/src/main/java/roguelike/Generation/World.java
+++ b/core/src/main/java/roguelike/Generation/World.java
@@ -57,13 +57,15 @@ public class World {
 		initialize_exits();
 
 		current_map = surface;
-
 		player = Factory.getInstance().initialize_player();
 		Factory.getInstance().build_player(player, starting_location, surface);
 		//Gdx.input.setInputProcessor(entityManager.gc(player, Command.class));
-		Gdx.input.setInputProcessor(entityManager.gc(player, Command.class));
-
 		turn_system = new Turn_System();
+		reload();
+	}
+	public void reload()
+	{
+		Gdx.input.setInputProcessor(entityManager.gc(player, Command.class));
 	}
 
 	public void initialize_exits(){

--- a/core/src/main/java/roguelike/engine/Game.java
+++ b/core/src/main/java/roguelike/engine/Game.java
@@ -1,6 +1,9 @@
 package roguelike.engine;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.StretchViewport;
@@ -40,18 +43,17 @@ public class Game extends com.badlogic.gdx.Game {
 
 	    setScreen(new Start_Screen(this));
     }
-    /*@Override
+    @Override
     public void render () {
         // standard clear the background routine for libGDX
-        Gdx.gl.glClearColor(current_screen.getBGColor().r / 255.0f, current_screen.getBGColor().g / 255.0f, current_screen.getBGColor().b / 255.0f, 1.0f);
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
-        current_screen.render();
-
-        stage.draw();
-        stage.act();
-
-    }*/
+        Screen screen = getScreen();
+        if(screen != null) 
+            screen.render(Gdx.graphics.getDeltaTime());
+//        stage.draw();
+//        stage.act();
+    }
 
     @Override
 	public void dispose(){

--- a/core/src/main/java/roguelike/screens/Equipment_Screen.java
+++ b/core/src/main/java/roguelike/screens/Equipment_Screen.java
@@ -5,14 +5,13 @@ import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import roguelike.engine.Game;
+import roguelike.utilities.Roll;
 import squidpony.squidgrid.gui.gdx.DefaultResources;
 import squidpony.squidgrid.gui.gdx.SColor;
 import squidpony.squidgrid.gui.gdx.SparseLayers;
 import squidpony.squidgrid.gui.gdx.SquidInput;
 
 import static roguelike.engine.Game.*;
-import static roguelike.engine.Game.cellHeight;
-import static roguelike.engine.Game.cellWidth;
 
 public class Equipment_Screen extends ScreenAdapter {
 
@@ -34,33 +33,41 @@ public class Equipment_Screen extends ScreenAdapter {
 		display.font.tweakWidth(cellWidth + 1).tweakHeight(cellHeight + 1).setSmoothingMultiplier(1.6f).initBySize();
 		bgColor = SColor.DB_MIDNIGHT;
 		display.fillBackground(bgColor);
-		stage.addActor(display);
+	//	stage.addActor(display);
 	}
 
 	@Override
 	public void show(){
-		/*input = new SquidInput((key, alt, ctrl, shift) -> {
-
+		stage.clear();
+		stage.addActor(display);
+		input = new SquidInput((key, alt, ctrl, shift) -> {
 			switch(key) {
 				case SquidInput.ENTER: {
 					game.setScreen(game.getGame_screen());
 					break;
 				}
+				default: {
+					display.put(Roll.rand(0, gridWidth-4), Roll.rand(0, gridHeight - 1), "Poop", SColor.CW_RICH_BROWN);
+					break;
+				}
 			}
 		});
 
-		Gdx.input.setInputProcessor(input);*/
+		Gdx.input.setInputProcessor(input);
 
 	}
 
 	@Override
 	public void render(float delta) {
-
-		display.clear();
-
-		display.put(display.gridWidth / 2, display.gridHeight / 2, "Poop", Color.WHITE);
-
+		display.put(display.gridWidth / 2, display.gridHeight / 2, "Poop", SColor.CW_RICH_BROWN);
 		stage.draw();
+		stage.act();
+		if(input.hasNext())
+			input.next();
 	}
 
+	@Override
+	public void hide() {
+		display.clear();
+	}
 }

--- a/core/src/main/java/roguelike/screens/Game_Screen.java
+++ b/core/src/main/java/roguelike/screens/Game_Screen.java
@@ -42,6 +42,7 @@ public class Game_Screen extends ScreenAdapter {
     @Override
     public void show(){
         stage = game.stage;
+        stage.clear();
         display = new SparseLayers(gridWidth, gridHeight, cellWidth, cellHeight, DefaultResources.getCrispDejaVuFont());
         display.font.tweakWidth(cellWidth + 1).tweakHeight(cellHeight + 1).setSmoothingMultiplier(1.6f).initBySize();
         //display = new SparseLayers(gridWidth, gridHeight, cellWidth, cellHeight, DefaultResources.getStretchableTypewriterFont());
@@ -50,15 +51,17 @@ public class Game_Screen extends ScreenAdapter {
         display.fillBackground(bgColor);
         map_height_start = message_buffer;
         map_height_end = gridHeight - statistics_height + message_buffer;
-        world = new World(gridWidth, gridHeight - statistics_height);
+        if(world != null)
+            world.reload();
+        else
+            world = new World(gridWidth, gridHeight - statistics_height);
         stage.addActor(display);
 
     }
 
     @Override
     public void render(float delta){
-
-    	display.clear();
+        display.clear();
         world.update();
 	    render_map();
         render_entities();
@@ -66,7 +69,7 @@ public class Game_Screen extends ScreenAdapter {
         render_messages();
 
         stage.draw();
-
+        stage.act();
     }
 
 	private void render_messages(){

--- a/core/src/main/java/roguelike/screens/Start_Screen.java
+++ b/core/src/main/java/roguelike/screens/Start_Screen.java
@@ -59,6 +59,7 @@ public class Start_Screen extends ScreenAdapter {
             input.next();
         }
         stage.draw();
+        stage.act();
     }
 
 	@Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx512m
 org.gradle.configureondemand=false
 regExodusVersion=0.1.10
-squidLibVersion=1d9ce00fe1
+squidLibVersion=0d898ff42a
 gdxVersion=1.9.8


### PR DESCRIPTION
This was more involved than I thought it would be. You can hit enter from the Equipment_Screen to close it and go back to where you just were, or any other key to randomly place words.

The placement of Actors on the Stage needed to be moved to show() in one place, and the screen is now cleared every frame with glClear to prevent overdraw of the font, which looks bad. An important note is that world.reload() must be called instead of new World() when you want to load an existing player and map. Since the player has Command as a component, if two players are created, one of their Command input handlers won't work at all. A few other places had weird issues related to the input handler changing in the middle of handling input; line 77 of Command.java is a critical one of these. If you remove that line, `lastKeyCode = -1;`, then returning from the equipment screen to the game screen will have bizarre bugs where either or both screens may be visible or flickering, and input won't go to the correct screen. The lastKeyCode field is used by the hold-key-to-repeat logic, which is interrupted when the current input handler changes as the screen does. It's probably a good idea to use `lastKeyCode = -1;` before any other screen changes in Command, but it doesn't seem to be needed (yet?) in other classes. Only Command or another subclass of SquidInput can access lastKeyCode, since it's protected, but I will probably update SquidLib and make that field public now that I know it's important to access.